### PR TITLE
Add module for PowerShell ISE to change the directory to the current file that is being edited.

### DIFF
--- a/Powershell/IseHelper.psm1
+++ b/Powershell/IseHelper.psm1
@@ -1,0 +1,12 @@
+# To change the location to the current item in the PowerShell ISE editor.
+Function Set-LocationToCurrentIseItem
+{
+	if ($null -eq $psISE)
+	{
+		Write-Error 'Function only supported in PowerShell ISE'
+	}
+	else
+	{
+		Set-Location (Split-Path $psISE.CurrentFile.FullPath -Parent)
+	}
+}


### PR DESCRIPTION
For issue #1:
A really helpful method to change location to the current item being edited. I use so often that I even have an alias for it. Setting the alias should however be up to the user.